### PR TITLE
Use single import instead of the full @tabler/icons package

### DIFF
--- a/compound-components/src/components/ContactList.tsx
+++ b/compound-components/src/components/ContactList.tsx
@@ -2,9 +2,9 @@ import { useState } from "react";
 import { Layout } from "./Layout";
 import { CreateNewContactModal } from "./CreateNewContactModal";
 import { Button } from "@mantine/core";
-import { IconPlus } from "@tabler/icons-react";
 import { ContactsTable } from "./ContactsTable";
 import { useContactsCount } from "../api/hooks";
+import IconPlus from '@tabler/icons-react/dist/esm/icons/IconPlus';
 
 type ContactListProps = {
   selectContactToEdit: (id: string) => void;

--- a/compound-components/src/components/ContactTableRow.tsx
+++ b/compound-components/src/components/ContactTableRow.tsx
@@ -1,9 +1,9 @@
 import { ActionIcon, Table } from "@mantine/core";
 import { useHover } from "@mantine/hooks";
-import { IconEdit } from "@tabler/icons-react";
 import { ContactOverview } from "../api/client";
 import { useOptimisticContactName } from "../api/hooks";
 import { MantineLink } from "./MantineLink";
+import IconEdit from '@tabler/icons-react/dist/esm/icons/IconEdit';
 
 type ContactTableRowProps = {
   contact: ContactOverview;

--- a/compound-components/src/components/CreateNewContactModal.tsx
+++ b/compound-components/src/components/CreateNewContactModal.tsx
@@ -7,10 +7,11 @@ import {
   Stack,
   TextInput,
 } from "@mantine/core";
-import { IconHome, IconPhone } from "@tabler/icons-react";
 import { useEffect, useState } from "react";
 import { useCreateContact } from "../api/hooks";
 import { useNavigate } from "@tanstack/react-router";
+import IconHome from '@tabler/icons-react/dist/esm/icons/IconHome';
+import IconPhone from '@tabler/icons-react/dist/esm/icons/IconPhone';
 
 type CreateNewContactModalProps = {
   isOpen: boolean;

--- a/compound-components/src/components/EditContactCompound.tsx
+++ b/compound-components/src/components/EditContactCompound.tsx
@@ -6,12 +6,13 @@ import {
   Stack,
   TextInput,
 } from "@mantine/core";
-import { IconHome, IconPhone } from "@tabler/icons-react";
 import { ReactNode, useEffect, useState } from "react";
 import { Contact } from "../api/client";
 import { useContactDetails, useEditContact } from "../api/hooks";
 import { createContext } from "../utils/createContext";
 import { Spinner } from "./Spinner";
+import IconHome from '@tabler/icons-react/dist/esm/icons/IconHome';
+import IconPhone from '@tabler/icons-react/dist/esm/icons/IconPhone';
 
 type FormContact = {
   firstName: string;

--- a/compound-components/src/components/Layout.tsx
+++ b/compound-components/src/components/Layout.tsx
@@ -1,7 +1,7 @@
 import { AppShell, Flex, Title } from "@mantine/core";
-import { IconAddressBook } from "@tabler/icons-react";
 import { Link } from "@tanstack/react-router";
 import { ReactNode } from "react";
+import IconAddressBook from '@tabler/icons-react/dist/esm/icons/IconAddressBook';
 
 type LayoutProps = {
   title: ReactNode;


### PR DESCRIPTION
Hey I come from YouTube, your video about compound components. 

I wanted to have a bit more details, I downloaded your repo, install, run the code - And - Huuuuuuuuge loading time ~50sec for this tiny app.

![Capture](https://github.com/user-attachments/assets/b723d982-d411-4257-90ee-68b0c91af6fd)

Turns out every single component from Tabler were downloaded.  There is an opened issue on the tabler repo => https://github.com/tabler/tabler-icons/issues/1233

The (temporary) fix was to import only one component instead of the package. The linter is complaining but the imports works fine and the loading time went from 50s to 700ms [related comment on the main repo](https://github.com/tabler/tabler-icons/issues/1233#issuecomment-2796371810)

